### PR TITLE
Remove useless trigger on PR for verify (duplicate)

### DIFF
--- a/.github/workflows/Verify.yml
+++ b/.github/workflows/Verify.yml
@@ -21,10 +21,7 @@ name: Verify
 
 # This workflow is triggered on every push to verify that the project builds correctly and runs Sonar + Unit tests
 
-on: 
-  push:
-  pull_request:
-    types: [opened, reopened]
+on: push
 
 jobs:
   call-verify-workflow:


### PR DESCRIPTION
When creating a PR, they trigger the Verify workflow.
However, commits already trigger Verify and the PR can use this workflow to confirm the PR was verified.

Hence there is no need to run Verify twice.