### PR TITLE
fix: PR trigger rollback if failure and workflow call reference

### DIFF
--- a/.github/workflows/Rollback-if-failure.yml
+++ b/.github/workflows/Rollback-if-failure.yml
@@ -20,7 +20,7 @@
 name: Rollback if failure
 
 # This CD workflow rollbacks the Pre-Release and Prepare next development version
-# When a PR is closed (based on do_release) or if the prepare-next-dev workflow fails
+# When a PR is closed (based on do_release and targeting master) or if the prepare-next-dev workflow fails
 # Proceeds to delete do_release branch, delete the pre-release and delete the tag
 
 on: 
@@ -28,10 +28,10 @@ on:
   pull_request:
     types: [closed]
     branches:    
-      - 'do_release'
+      - master
 
 jobs:
   call-rollback-if-failure-workflow:
-    if: github.event.pull_request.merged == false
+    if: github.event.pull_request.merged == false && startsWith(github.head_ref, 'do_release')
     name: Rollback if failure
-    uses: riseclipse/riseclipse-developer/.github/workflows/Shared-Rollback-If-Failure.yml@workflows/rollback-if-failure
+    uses: riseclipse/riseclipse-developer/.github/workflows/Shared-Rollback-If-Failure.yml@master


### PR DESCRIPTION
I've tested on another project how to trigger an action or PR closed and was able to find the error in my workflow.

The branches attribute on the trigger is for the target and not the branch.
But I had to find a solution because I couldn't trigger the workflow everytime there is a closed PR on master.
So I was able to add the base branch being `do_release` as an if condition.

See test here: https://github.com/SoaAlex/PR_Trigger_Test

Also, this changes the reference of the reusable workflow to master (forgot to do it before merging)