### PR TITLE
Add snapshot testing to Verify workflow

### DIFF
--- a/.github/workflows/Verify.yml
+++ b/.github/workflows/Verify.yml
@@ -26,7 +26,7 @@ on: push
 jobs:
   call-verify-workflow:
     name: Verify Project
-    uses: riseclipse/riseclipse-developer/.github/workflows/Shared-Verify-Tools.yml@master
+    uses: riseclipse/riseclipse-developer/.github/workflows/Shared-Verify-Tools.yml@snapshot-tests-workflow
     with:
       jarPath1: riseclipse-validator-scl2003/fr.centralesupelec.edf.riseclipse.iec61850.scl.validator/target/RiseClipseValidatorSCL.jar
       jarPath2: riseclipse-validator-scl2003/fr.centralesupelec.edf.riseclipse.iec61850.scl.validator.ui/target/RiseClipseValidatorSCLApplication.jar
@@ -45,15 +45,15 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           name: ${{ needs.call-verify-workflow.outputs.artifact1Name }}
-          path: ${{ github.workspace }}/SCLValidator.jar
+          path: scl-validator
 
       - name: Checkout riseclipse-validator-scl2003-test
         uses: actions/checkout@v3
         with:
           repository: riseclipse/riseclipse-validator-scl2003-test
-          path: ${{ github.workspace }}/riseclipse-validator-scl2003-test
+          path: riseclipse-validator-scl2003-test
 
       - name: Run SCL validator snapshot tests
         run: |
-          cd ${{ github.workspace }}/riseclipse-validator-scl2003-test
-          python run_tests.py --jar-path ${{ github.workspace }}/SCLValidator.jar
+          cd riseclipse-validator-scl2003-test
+          python run_tests.py --jar-path ${{ github.workspace }}/scl-validator/${{ needs.call-verify-workflow.outputs.artifact1Name }}

--- a/.github/workflows/Verify.yml
+++ b/.github/workflows/Verify.yml
@@ -28,8 +28,8 @@ jobs:
     name: Verify Project
     uses: riseclipse/riseclipse-developer/.github/workflows/Shared-Verify-Tools.yml@snapshot-tests-workflow
     with:
-      jarPath1: riseclipse-validator-scl2003/fr.centralesupelec.edf.riseclipse.iec61850.scl.validator/target/RiseClipseValidatorSCL.jar
-      jarPath2: riseclipse-validator-scl2003/fr.centralesupelec.edf.riseclipse.iec61850.scl.validator.ui/target/RiseClipseValidatorSCLApplication.jar
+      jar_path_1: riseclipse-validator-scl2003/fr.centralesupelec.edf.riseclipse.iec61850.scl.validator/target/RiseClipseValidatorSCL.jar
+      jar_path_2: riseclipse-validator-scl2003/fr.centralesupelec.edf.riseclipse.iec61850.scl.validator.ui/target/RiseClipseValidatorSCLApplication.jar
 
   snapshot-tests:
     name: SCL Validator Snapshot Tests
@@ -45,7 +45,7 @@ jobs:
       - name: Download SCL validator jar
         uses: actions/download-artifact@v3
         with:
-          name: ${{ needs.call-verify-workflow.outputs.artifact1Name }}
+          name: ${{ needs.call-verify-workflow.outputs.artifact_1_name }}
           path: scl-validator
 
       - name: Checkout riseclipse-validator-scl2003-test
@@ -57,4 +57,4 @@ jobs:
       - name: Run SCL validator snapshot tests
         run: |
           cd riseclipse-validator-scl2003-test
-          python run_tests.py --jar-path ${{ github.workspace }}/scl-validator/${{ needs.call-verify-workflow.outputs.artifact1Name }}
+          python run_tests.py --jar-path ${{ github.workspace }}/scl-validator/${{ needs.call-verify-workflow.outputs.artifact_1_name }}

--- a/.github/workflows/Verify.yml
+++ b/.github/workflows/Verify.yml
@@ -26,7 +26,7 @@ on: push
 jobs:
   call-verify-workflow:
     name: Verify Project
-    uses: riseclipse/riseclipse-developer/.github/workflows/Shared-Verify-Tools.yml@snapshot-tests-workflow
+    uses: riseclipse/riseclipse-developer/.github/workflows/Shared-Verify-Tools.yml@master
     with:
       jar_path_1: riseclipse-validator-scl2003/fr.centralesupelec.edf.riseclipse.iec61850.scl.validator/target/RiseClipseValidatorSCL.jar
       jar_path_2: riseclipse-validator-scl2003/fr.centralesupelec.edf.riseclipse.iec61850.scl.validator.ui/target/RiseClipseValidatorSCLApplication.jar

--- a/.github/workflows/Verify.yml
+++ b/.github/workflows/Verify.yml
@@ -41,19 +41,19 @@ jobs:
         with:
           python-version: "3.10"
 
-      - name: Checkout riseclipse-validator-scl2003-test
-        uses: actions/checkout@v3
-        with:
-          repository: riseclipse/riseclipse-validator-scl2003-test
-          path: riseclipse-validator-scl2003-test
-
       - name: Download SCL validator jar
         uses: actions/download-artifact@v3
         with:
           name: ${{ needs.call-verify-workflow.outputs.artifact1Name }}
-          path: riseclipse-validator-scl2003-test/SCLValidator.jar
+          path: ${{ github.workspace }}/SCLValidator.jar
+
+      - name: Checkout riseclipse-validator-scl2003-test
+        uses: actions/checkout@v3
+        with:
+          repository: riseclipse/riseclipse-validator-scl2003-test
+          path: ${{ github.workspace }}/riseclipse-validator-scl2003-test
 
       - name: Run SCL validator snapshot tests
         run: |
-          cd riseclipse-validator-scl2003-test
-          python run_tests.py --jar-path SCLValidator.jar
+          cd ${{ github.workspace }}/riseclipse-validator-scl2003-test
+          python run_tests.py --jar-path ${{ github.workspace }}/SCLValidator.jar

--- a/.github/workflows/Verify.yml
+++ b/.github/workflows/Verify.yml
@@ -32,6 +32,7 @@ jobs:
       jarPath2: riseclipse-validator-scl2003/fr.centralesupelec.edf.riseclipse.iec61850.scl.validator.ui/target/RiseClipseValidatorSCLApplication.jar
 
   snapshot-tests:
+    name: SCL Validator Snapshot Tests
     runs-on: ubuntu-latest
     needs: call-verify-workflow
 

--- a/.github/workflows/Verify.yml
+++ b/.github/workflows/Verify.yml
@@ -4,9 +4,9 @@
 # **  are made available under the terms of the Eclipse Public License v2.0
 # **  which accompanies this distribution, and is available at
 # **  https://www.eclipse.org/legal/epl-v20.html
-# ** 
+# **
 # **  This file is part of the RiseClipse tool
-# **  
+# **
 # **  Contributors:
 # **      Computer Science Department, CentraleSupélec
 # **      EDF R&D
@@ -30,3 +30,30 @@ jobs:
     with:
       jarPath1: riseclipse-validator-scl2003/fr.centralesupelec.edf.riseclipse.iec61850.scl.validator/target/RiseClipseValidatorSCL.jar
       jarPath2: riseclipse-validator-scl2003/fr.centralesupelec.edf.riseclipse.iec61850.scl.validator.ui/target/RiseClipseValidatorSCLApplication.jar
+
+  snapshot-tests:
+    runs-on: ubuntu-latest
+    needs: call-verify-workflow
+
+    steps:
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v3
+        with:
+          python-version: "3.10"
+
+      - name: Checkout riseclipse-validator-scl2003-test
+        uses: actions/checkout@v3
+        with:
+          repository: riseclipse/riseclipse-validator-scl2003-test
+          path: riseclipse-validator-scl2003-test
+
+      - name: Download SCL validator jar
+        uses: actions/download-artifact@v3
+        with:
+          name: ${{ needs.call-verify-workflow.outputs.artifact1Name }}
+          path: riseclipse-validator-scl2003-test/SCLValidator.jar
+
+      - name: Run SCL validator snapshot tests
+        run: |
+          cd riseclipse-validator-scl2003-test
+          python run_tests.py --jar-path SCLValidator.jar


### PR DESCRIPTION
Adding a job to the Verify workflow to launch SCL validator snapshot tests.
Depends on [this PR](https://github.com/riseclipse/riseclipse-developer/pull/30) which allows our job to fetch names for the artifacts we need.