### PR TITLE
remove incorrect search of a CDCValidator using only CDC's name

### DIFF
--- a/fr.centralesupelec.edf.riseclipse.iec61850.scl.validator/src/fr/centralesupelec/edf/riseclipse/iec61850/scl/validator/nsd/CDCValidator.java
+++ b/fr.centralesupelec.edf.riseclipse.iec61850.scl.validator/src/fr/centralesupelec/edf/riseclipse/iec61850/scl/validator/nsd/CDCValidator.java
@@ -70,24 +70,6 @@ public class CDCValidator {
         return Pair.of( cdcValidator, nsIdentification );
     }
     
-    public static Pair< CDCValidator, NsIdentification > getByName( NsIdentification nsIdentification, String cdcName ) {
-        NsIdentification nsId = nsIdentification;
-        while( nsId != null ) {
-            for( CDCValidator validator : validators.values() ) {
-                if( validator.getName().equals( cdcName )) {
-                    // If the CDC is parameterized, there is no way to get the right parameter
-                    if( validator.cdc.isEnumParameterized() || validator.cdc.isTypeKindParameterized() ) {
-                        return Pair.of( null, nsIdentification );
-                    }
-                    return Pair.of( validator, nsIdentification );
-                }
-            }
-            nsIdentification = nsId;
-            nsId = nsId.getDependsOn();
-        }
-        return Pair.of( null, nsIdentification );
-    }
-    
     public static void buildValidators( NsIdentification nsIdentification, Stream< CDC > stream, IRiseClipseConsole console ) {
         stream
         .forEach( cdc -> validators.put(
@@ -358,7 +340,6 @@ public class CDCValidator {
         IRiseClipseConsole console = AbstractRiseClipseConsole.getConsole();
         console.debug( CDC_VALIDATION_NSD_CATEGORY, do_.getLineNumber(),
                 "CDCValidator( ", getName(), " ).validateDO( ", do_.getName(), " ) in namespace \"", nsIdentification, "\"" );
-        
         DOType doType = do_.getRefersToDOType();
         if( doType == null ) {
             RiseClipseMessage error = RiseClipseMessage.warning( CDC_VALIDATION_NSD_CATEGORY, do_.getFilename(), do_.getLineNumber(), 

--- a/fr.centralesupelec.edf.riseclipse.iec61850.scl.validator/src/fr/centralesupelec/edf/riseclipse/iec61850/scl/validator/nsd/LNClassValidator.java
+++ b/fr.centralesupelec.edf.riseclipse.iec61850.scl.validator/src/fr/centralesupelec/edf/riseclipse/iec61850/scl/validator/nsd/LNClassValidator.java
@@ -234,45 +234,15 @@ public class LNClassValidator {
                 }
             }
             else {
-                if( do_.getRefersToDOType() == null ) {
-                    RiseClipseMessage error = RiseClipseMessage.warning( LNCLASS_VALIDATION_NSD_CATEGORY, do_.getFilename(), do_.getLineNumber(), 
-                            "DO \"", do_.getName(), "\" cannot be verified because its DOType is unknown" );
-                    diagnostics.add( new BasicDiagnostic(
-                            Diagnostic.WARNING,
-                            RiseClipseValidatorSCL.DIAGNOSTIC_SOURCE,
-                            0,
-                            error.getMessage(),
-                            new Object[] { do_, error } ));
-                    res = false;
-                    continue;
-                }
-
-                Pair< CDCValidator, NsIdentification > pair = CDCValidator.getByName( NsIdentification.of( do_.getNamespace() ), do_.getRefersToDOType().getCdc() );
-                CDCValidator cdcValidator = pair.getLeft();
-                if( cdcValidator != null ) {
-                    RiseClipseMessage notice = RiseClipseMessage.notice( LNCLASS_VALIDATION_NSD_CATEGORY, do_.getFilename(), do_.getLineNumber(), 
-                            "DO \"", do_.getName(), "\" cannot be checked against the CDC given by the LNClass of its AnyLN  because its namespace \"",
-                            do_.getNamespace(), "\" differs from current namespace \"", nsIdentification, "\". It will be checked using the CDC ",
-                            " of its DOType \"", do_.getRefersToDOType().getCdc(), "\"" );
-                    diagnostics.add( new BasicDiagnostic(
-                            Diagnostic.INFO,
-                            RiseClipseValidatorSCL.DIAGNOSTIC_SOURCE,
-                            0,
-                            notice.getMessage(),
-                            new Object[] { do_, notice } ));
-                    res = cdcValidator.validateDO( do_, diagnostics ) && res;
-                }
-                else {
-                    RiseClipseMessage warning = RiseClipseMessage.warning( LNCLASS_VALIDATION_NSD_CATEGORY, do_.getFilename(), do_.getLineNumber(), 
-                            "DO \"", do_.getName(), "\" cannot be verified because there is no CDC validator for it in namespace \"" + do_.getNamespace() + "\"" );
-                    diagnostics.add( new BasicDiagnostic(
-                            Diagnostic.WARNING,
-                            RiseClipseValidatorSCL.DIAGNOSTIC_SOURCE,
-                            0,
-                            warning.getMessage(),
-                            new Object[] { do_, warning } ));
-                    
-                }
+                RiseClipseMessage warning = RiseClipseMessage.warning( LNCLASS_VALIDATION_NSD_CATEGORY, do_.getFilename(), do_.getLineNumber(), 
+                        "DO \"", do_.getName(), "\" cannot be verified because there is no CDC validator for it in namespace \"" + do_.getNamespace() + "\"" );
+                diagnostics.add( new BasicDiagnostic(
+                        Diagnostic.WARNING,
+                        RiseClipseValidatorSCL.DIAGNOSTIC_SOURCE,
+                        0,
+                        warning.getMessage(),
+                        new Object[] { do_, warning } ));
+                
             }
         }
         


### PR DESCRIPTION
The namespace must be take into account