### PR TITLE
Add pytest-xdist to run tests in parallel

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,7 @@ RUN \
   && apt-get install -y \
        python3 \
        python3-pytest \
+       python3-pytest-xdist \
        python3-jinja2 \
        zip \
   && ln -s /usr/bin/python3 /usr/bin/python \


### PR DESCRIPTION
I would like to add another package that will allow us to run our CI tests in parallel.