### PR TITLE
More packages are needed for IEC 61850-6-3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,9 +4,9 @@
 # **  are made available under the terms of the Eclipse Public License v2.0
 # **  which accompanies this distribution, and is available at
 # **  https://www.eclipse.org/legal/epl-v20.html
-# ** 
+# **
 # **  This file is part of the RiseClipse tool
-# **  
+# **
 # **  Contributors:
 # **      Computer Science Department, CentraleSupélec
 # **      EDF R&D
@@ -17,7 +17,7 @@
 # **      https://riseclipse.github.io
 # *************************************************************************
 
-FROM eclipse-temurin:17 as jre-build
+FROM eclipse-temurin:17 AS jre-build
 
 # Create a custom Java runtime
 RUN                                         \
@@ -38,22 +38,20 @@ ENV TZ=Europe/Paris
 ARG DEBIAN_FRONTEND=noninteractive
 
 ENV JAVA_HOME=/opt/java/openjdk
-ENV PATH "${JAVA_HOME}/bin:${PATH}"
+ENV PATH="${JAVA_HOME}/bin:${PATH}"
 COPY --from=jre-build /javaruntime $JAVA_HOME
 
-RUN                                         \
-     apt-get update                         \
-  && apt-get install -y                     \
-       python3                              \
-       python3-pytest                       \
-       python3-pytest-xdist                 \
-       python3-jinja2                       \
-  && ln -s /usr/bin/python3 /usr/bin/python \
-  && apt-get clean                          \
-  && rm -rf                                 \
-       /tmp/*                               \
-       /var/lib/apt/lists/*                 \
-       /var/tmp/*
+RUN apt update \
+    && apt install -y curl \
+        texlive-latex-base make zip texlive-latex-base \
+        texlive-latex-extra latexmk tex-gyre \
+     && apt-get clean \
+     && rm -rf \
+          /tmp/* \
+          /var/lib/apt/lists/* \
+          /var/tmp/*
+COPY --from=ghcr.io/astral-sh/uv:0.6.0 /uv /uvx /bin/
+
 
 # "Download artifact" action creates subdirectory named from the artifact's name
 COPY artifacts/RiseClipseValidatorSCL-*/RiseClipseValidatorSCL-*.jar /usr/riseclipse/bin/RiseClipseValidatorSCL.jar


### PR DESCRIPTION
This change allows us to automatically build documentation in the docker container using some python packages.